### PR TITLE
解决遮罩默认不覆盖前面的弹出层的问题

### DIFF
--- a/src/iframe.vue
+++ b/src/iframe.vue
@@ -91,7 +91,10 @@ export default {
       if (domZindex == max && max != 500) {
         return;
       }
-      this.zindex = max + 1;
+      this.zindex = max + 2;
+      if(this.options.shadeCover) {
+          this.options.layer.instancesVue[this.options.id].mask.$el.style.zIndex = this.zindex-1;
+      }
     },
     async getContent() {
       await helper.sleep(10);

--- a/src/layer.js
+++ b/src/layer.js
@@ -28,7 +28,8 @@ let Notification = (function(vue, globalOption = {
     cancel: '',
     tips: [0, {}], //支持上右下左四个方向，通过1-4进行方向设定,可以设定tips: [1, '#c00']
     tipsMore: false, //是否允许多个tips
-    shadeClose: true
+    shadeClose: true,
+    shadeCover: false, //默认遮罩不覆盖上级弹出层
   };
   self.instances = {};
   self.instancesVue = [];


### PR DESCRIPTION
添加shadeCover参数，允许遮罩遮住之前的弹出层，默认为false