### PR TITLE
Update drag.vue

### DIFF
--- a/packages/layer/src/components/drag/drag.vue
+++ b/packages/layer/src/components/drag/drag.vue
@@ -199,6 +199,7 @@ export default {
       }
       this.addStyle = {
         overflow: "hidden",
+        top: "50%",
         left: "50%",
         width: "100%",
         height: height + "px",


### PR DESCRIPTION
最大化的时候，先初始化位置.修改拖拽位置后，最大化不能填充界面问题